### PR TITLE
[MCH] added ostream parameter to PreCluster::print() function

### DIFF
--- a/Detectors/MUON/MCH/Base/include/MCHBase/PreCluster.h
+++ b/Detectors/MUON/MCH/Base/include/MCHBase/PreCluster.h
@@ -33,7 +33,7 @@ struct PreCluster {
   /// return the index of last associated digit in the ordered vector of digits
   uint16_t lastDigit() const { return firstDigit + nDigits - 1; }
 
-  void print(gsl::span<const Digit> digits) const;
+  void print(std::ostream& stream, gsl::span<const Digit> digits) const;
 };
 
 } // namespace mch

--- a/Detectors/MUON/MCH/Base/src/PreCluster.cxx
+++ b/Detectors/MUON/MCH/Base/src/PreCluster.cxx
@@ -25,20 +25,19 @@ namespace mch
 using namespace std;
 
 //_________________________________________________________________
-void PreCluster::print(gsl::span<const Digit> digits) const
+void PreCluster::print(std::ostream& stream, gsl::span<const Digit> digits) const
 {
   /// print the precluster, getting the associated digits from the provided span
 
   if (lastDigit() >= digits.size()) {
-    cout << "the vector of digits is too small to contain the digits of this precluster" << endl;
+    stream << "the vector of digits is too small to contain the digits of this precluster" << endl;
   }
 
-  cout << "{nDigits= " << nDigits;
   int i(0);
+  stream << "  nDigits = " << nDigits << std::endl;
   for (const auto& digit : digits.subspan(firstDigit, nDigits)) {
-    cout << ", digit[" << i++ << "]= " << digit.getPadID();
+    stream << "  digit[" << i++ << "] = " << digit.getDetID() << "," << digit.getPadID() << "," << digit.getADC() << std::endl;
   }
-  cout << "}" << endl;
 }
 
 } // namespace mch

--- a/Detectors/MUON/MCH/PreClustering/src/PreClusterFinderSpec.cxx
+++ b/Detectors/MUON/MCH/PreClustering/src/PreClusterFinderSpec.cxx
@@ -112,7 +112,7 @@ class PreClusterFinderTask
     if (mPrint) {
       cout << mPreClusters.size() << " preclusters:" << endl;
       for (const auto& precluster : mPreClusters) {
-        precluster.print(mUsedDigits);
+        precluster.print(cout, mUsedDigits);
       }
     }
 


### PR DESCRIPTION
I have added a `stream` parameter of type `std::ostream` to the `PreCluster::print()` function, and changed a bit the way of printing the digits. The output now shows one digit per line, in the format
```
  digit[i] = detID, padID, ADC
```
which is more readable and provides more informations.